### PR TITLE
Update Docker base image to support API version 1.44

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpinelinux/docker-cli:latest
+FROM docker:29.1.3-cli-alpine3.23
 
 LABEL maintainer="kitconcept GmbH <info@kitconcept.com>" \
       org.label-schema.name="docker-stack-deploy" \


### PR DESCRIPTION
This PR updates the Docker image version to resolve a compatibility issue with the Docker daemon.

Problem:
The current setup was failing with the following error:
Error response from daemon: client version 1.41 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version

Solution:
Updated the Docker base image (and/or related CI/CD configurations) to ensure compatibility with Docker API version 1.44 or higher.

Changes:
Updated Dockerfile base image to docker:29.1.3-cli-alpine3.23.