### PR TITLE
Support empty username and password for docker login.

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -96,7 +96,7 @@ else
 fi
 
 # PROCEED WITH LOGIN
-if [ -z "${USERNAME+x}" ] || [ -z "${PASSWORD+x}" ]; then
+if [ -z "${USERNAME}" ] || [ -z "${PASSWORD}" ]; then
   echo "Container Registry: No authentication provided"
 else
   [ -z ${REGISTRY+x} ] && export REGISTRY=""


### PR DESCRIPTION
For background, see issue #11, but that has a bigger picture than you need to review this PR.

In my testing, the check for an empty USERNAME by doing `-z "${USERNAME+x}"` always fails: it is never empty. The `+x` seems wrong to me.  A trick like that can be needed when comparing two strings, but not when checking if a single string is empty.

I have tested in a shell.  First without the `USERNAME` variable existing at all:

```
$ env | grep USERNAME
$ if [ -z "${USERNAME+x}" ] ; then echo "empty"; fi
empty
$ if [ -z "${USERNAME}" ] ; then echo "empty"; fi
empty
```

Fine.

Now with `USERNAME` variable defined, and not empty:

```
$ export USERNAME=me
$ if [ -z "${USERNAME+x}" ] ; then echo "empty"; fi
$ if [ -z "${USERNAME}" ] ; then echo "empty"; fi
```

Also fine.

Now with `USERNAME` variable defined, but empty:

```
$ export USERNAME=
$ if [ -z "${USERNAME+x}" ] ; then echo "empty"; fi
$ if [ -z "${USERNAME}" ] ; then echo "empty"; fi
empty
```

The check with `+x` is wrong here.

I have tested my fix on a different branch, where I did some extra changes so I could make my own docker image available.  Usage is then like this:

```
      - name: Deploy to cluster
        uses: mauritsvanrees/docker-stack-deploy@maurits-empty-username-password
        with:
          registry: "ghcr.io"
          # These no longer need to be passed:
          # username: ${{ github.actor }}
          # password: ${{ secrets.DEPLOY_GHCR_READ_TOKEN }}
```